### PR TITLE
Added methods for borrowing messages from dbus

### DIFF
--- a/src/simpledbus/base/Connection.cpp
+++ b/src/simpledbus/base/Connection.cpp
@@ -66,6 +66,15 @@ Message Connection::pop_message() {
     }
 }
 
+Message Connection::borrow_message() {
+    DBusMessage* msg = dbus_connection_borrow_message(conn);
+    if (msg == nullptr) {
+        return Message();
+    } else {
+        return Message(msg, conn);
+    }
+}
+
 uint32_t Connection::send(Message& msg) {
     uint32_t msg_serial = 0;
     bool success = dbus_connection_send(conn, msg._msg, &msg_serial);

--- a/src/simpledbus/base/Connection.h
+++ b/src/simpledbus/base/Connection.h
@@ -22,6 +22,7 @@ class Connection {
 
     void read_write();
     Message pop_message();
+    Message borrow_message();
 
     uint32_t send(Message &msg);
     Message send_with_reply_and_block(Message &msg);

--- a/src/simpledbus/base/Message.h
+++ b/src/simpledbus/base/Message.h
@@ -34,6 +34,7 @@ class Message {
     bool _iter_initialized;
     bool _is_extracted;
     Holder _extracted;
+    DBusConnection* _borrowed_from;
     DBusMessage* _msg;
 
     Holder _extract_bytearray(DBusMessageIter* iter);
@@ -47,7 +48,7 @@ class Message {
 
   public:
     Message();
-    Message(DBusMessage* msg);
+    Message(DBusMessage* msg, DBusConnection* borrowed_from = nullptr);
     Message(Message&& other) = delete;         // Remove the move constructor
     Message(const Message& other) = delete;    // Remove the copy constructor
     Message& operator=(Message&& other);       // Implement custom move assignment
@@ -55,7 +56,12 @@ class Message {
     ~Message();
 
     bool is_valid() const;
+    void release();
     void append_argument(Holder argument, std::string signature);
+    
+    bool is_borrowed() const;
+    void steal_if_borrowed();
+    void copy_if_borrowed();
 
     Holder extract();
     void extract_reset();


### PR DESCRIPTION
I implemented this at one point if it's of interest.

Messages apparently have a state where they can be "borrowed" from dbus's message queue, locking the queue, and later either returned or stolen, unlocking the queue.  This PR attempts to provide access to this functionality.
