### PR TITLE
Initial attempt to set up build process to be usable through conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/find")
 
 project(SIMPLEDBUS)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 option(LIBFMT_VENDORIZE "Enable vendorized libfmt" ON)
 
 # Detect if the project is being build within a project or standalone.
@@ -24,7 +29,12 @@ include(FetchContent)
 find_package(PkgConfig REQUIRED)
 
 # Load libdbus-1
-pkg_search_module(DBUS REQUIRED dbus-1)
+if (CONAN_BUILD)
+	# conan packages this differently than a normall install, see https://github.com/conan-io/conan-center-index/blob/master/recipes/dbus/1.x.x/conanfile.py
+    find_package(DBus1 REQUIRED)
+else()
+    pkg_search_module(DBUS REQUIRED dbus-1)
+endif()
 
 # Load default parameters passed in through the command line.
 find_package(fmt REQUIRED)
@@ -72,6 +82,10 @@ target_link_libraries(simpledbus PRIVATE fmt::fmt-header-only)
 if(NOT ${STANDALONE})
     set(SIMPLEDBUS_INCLUDES ${SIMPLEDBUS_ALL_INCLUDE_DIRS} PARENT_SCOPE)
 endif()
+
+if (CONAN_BUILD)
+    add_subdirectory(examples)
+endif()    
 
 # Append additional flags for address and thread sanitization
 if(SIMPLEDBUS_SANITIZE MATCHES "Address")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,43 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
+import os
+
+class SimpleDBus(ConanFile):
+   name = "simpledbus"
+   license = "MIT"
+   description = "A simple C++ wrapper around DBus with a commercially-friendly licence"
+   settings = "os", "compiler", "build_type", "arch"
+   requires = "dbus/1.12.20", "fmt/7.1.3"
+   options = {
+      "log_level": ["VERBOSE_3","VERBOSE_2","VERBOSE_1","VERBOSE_0","DEBUG","INFO","WARNING","ERROR","FATAL"],
+      "shared": [True, False]
+   }
+   default_options = {
+      "fmt:header_only" : True,
+      "log_level" : "FATAL"
+   }
+   generators = ["cmake_find_package","cmake"]
+   
+   exports_sources = "CMakeLists.txt", "include/*",  "src/*",  "examples/*"
+
+   def build(self):
+      cmake = CMake(self)
+      cmake.definitions["SIMPLEDBUS_LOG_LEVEL"] = self.options.log_level
+      cmake.definitions["CONAN_BUILD"] = True
+      cmake.configure()
+      cmake.build()
+
+   def package(self):
+        self.copy("*.h", dst="include", src="include")
+        self.copy("*.hpp", dst="include", src="include")
+        if self.options.shared == True:
+           self.copy("*.so", dst="lib", keep_path=False)
+        else:
+           self.copy("*.a", dst="lib", keep_path=False)
+        self.copy("*", dst="bin", src="examples/notification/bin", keep_path=False)
+
+   def package_info(self):
+      self.cpp_info.libs = tools.collect_libs(self)
+   
+   def deploy(self):
+      self.copy("*", dst="bin", src="bin")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,9 +9,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Include simpledbus
-# Build artifacts in a separate folder
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. ${CMAKE_BINARY_DIR}/simpledbus)
-include_directories(${SIMPLEDBUS_INCLUDES})
+if (NOT CONAN_BUILD)
+    # Include simpledbus
+    # Build artifacts in a separate folder
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/.. ${CMAKE_BINARY_DIR}/simpledbus)
+    include_directories(${SIMPLEDBUS_INCLUDES})
+endif()
 
 add_subdirectory(notification)

--- a/examples/notification/CMakeLists.txt
+++ b/examples/notification/CMakeLists.txt
@@ -2,6 +2,16 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(EXAMPLE_NOTIFICATION)
 
+if (CONAN_BUILD)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
 message("-- [INFO] Building Example")
 add_executable(example_notification main.cpp)
-target_link_libraries(example_notification simpledbus-static)
+if (CONAN_BUILD)
+    target_include_directories(example_notification PUBLIC ${CONAN_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include)
+    target_link_libraries(example_notification ${CONAN_LIBS} simpledbus-static)
+else()
+    target_link_libraries(example_notification simpledbus-static)
+endif()

--- a/include/simpledbus/base/Logging.h
+++ b/include/simpledbus/base/Logging.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <cstdint>
 #include <string>
 

--- a/src/base/Exceptions.cpp
+++ b/src/base/Exceptions.cpp
@@ -1,6 +1,6 @@
 #include <simpledbus/base/Exceptions.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace SimpleDBus {
 


### PR DESCRIPTION
Hello!  I have done an initial attempt at making this library usable with a conan build and packaging.  My goals were to change as little as possible in the build process so that it could continue to be built as is if desired.

In order to build via conan I am generally using docker images.  In this case I used images conanio/gcc8-armv7hf and conanio/gcc10 to test.  If you create a docker image using these and have access to the source you can run a command like this to build the library and create the conan package.  I use VS Code which has some good support for running your code inside docker images

`conan create . simpledbus/2.1.1@ -s compiler.libcxx=libstdc++11 -o shared=False --build=missing`

The version number is arbitrary based on whatever version you are packaging but I chose the next version for this example.  The "--build=missing" option tells conan that it can build missing packages by pulling from conan center (https://conan.io/center/) and then using the same settings (compiler, arch, build_type, etc.) to build the dependencies.

A few notes on general setup with Conan and what I did:

- In the existing build both the static and shared library versions are built at once.  Conan generally uses this as a setting so that users of a package pick by option used rather than by specifying the library type in the build.  For this I have not changed the compilation but only the packaging so that only the appropriate library goes based on the option used (like False in the example above).  Ideally in the longer term the compilation would be set up to only build one with the library type defined by the option.
- I changed the build for conan so that the examples are always included.  For now I also included them in the package so that they can be used by a "conan deploy" operation.  This lets people try out the example executables without having to build if they have the appropriate setup. 
- I did not do anything with tests.  Conan has the ability to include this but it looked like a bit much for now.

I changed the includes for the fmt library to include format.h instead of core.h.  I believe this is the correct method and when I tried to use it without the examples were not linking because the library was including references to fmt symbols that were not already compiled in.

Please check it out and let me know if you have any questions or problems with it.  Conan is a great system and it will allow you to really get dependencies set up correctly if you use the versioning as it was intended so that a version of something clearly knows what the versions of the dependencies are.